### PR TITLE
(patch) remove eslint-plugin-no-autofix rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,8 +115,8 @@ module.exports = {
 			}
 		],
 		'no-alert': 'error',
-		'no-autofix/no-console': 'error',
-		'no-autofix/no-debugger': 'error',
+		'no-console': 'error',
+		'no-debugger': 'error',
 		'no-bitwise': 'warn',
 		'no-const-assign': 'error',
 		'no-dupe-class-members': 'error',

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "eslint": "5.x",
     "eslint-plugin-html": ">= 5",
     "eslint-plugin-import": ">= 2",
-    "eslint-plugin-mocha": ">= 5",
-    "eslint-plugin-no-autofix": "0.0.3"
+    "eslint-plugin-mocha": ">= 5"
   },
   "peerDependencies": {
     "babel-eslint": ">= 10",


### PR DESCRIPTION
It seems that eslint does not autofix no-console and no-debugger rules.

Sorry about that, @dotpointer!