### PR TITLE
one-var: consecutive const

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,8 +177,9 @@ module.exports = {
 		'one-var': [
 			'error',
 			{
-				var: 'always',
-				let: 'always'
+				const: 'consecutive',
+				let: 'always',
+				var: 'always'
 			}
 		],
 		'one-var-declaration-per-line': ['error', 'always'],


### PR DESCRIPTION
Make sure to combine const declarations to a single statement when
they are consecutive.
This has been part of the guidelines for quite some time but
didn't realize it could be formally enforced in the eslint ruleset.
Also something we don't want to be nit-picky about in PRs.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>