### PR TITLE
fix: drop class-methods-use-this, add object guideline rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "eslint.packageManager": "yarn",
+    "eslint.validate": [ "javascript", "html" ],
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/node_modules/**": true
+    },
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "eslint.packageManager": "yarn",
+    "eslint.packageManager": "npm",
     "eslint.validate": [ "javascript", "html" ],
     "files.watcherExclude": {
         "**/.git/objects/**": true,

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ module.exports = {
 		'block-spacing': 'error',
 		'brace-style': 'error',
 		camelcase: 'error',
-		'class-methods-use-this': 'warn',
 		'comma-dangle': ['error', 'never'],
 		'comma-spacing': [
 			'error',
@@ -164,17 +163,22 @@ module.exports = {
 		'no-whitespace-before-property': 'error',
 		'no-with': 'error',
 		'object-curly-newline': [
-			'error',
+			'warn',
 			{
-				consistent: true
+				consistent: true,
+				minProperties: 2,
+				multiline: true
 			}
 		],
-		'object-property-newline': [
-			'error',
+		'object-curly-spacing': [
+			'warn',
+			'always',
 			{
-				allowAllPropertiesOnSameLine: true
+				arraysInObjects: false,
+				objectsInObjects: false
 			}
 		],
+		'object-property-newline': ['warn'],
 		'object-shorthand': ['error', 'always'],
 		'one-var': [
 			'error',


### PR DESCRIPTION
- use-this will have to wait until we're more lit/haunted
- object-curly-newline should be needed on more than 2 props
- object-curly-spacing enforcement
- add .vscode settings

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>